### PR TITLE
Support passing environment variables (which can be arbitrary key-val…

### DIFF
--- a/lib/throng.js
+++ b/lib/throng.js
@@ -31,12 +31,13 @@ module.exports = function throng(options, startFunction) {
   const opts = isNaN(options) ?
     defaults(options, DEFAULT_OPTIONS) : defaults({ workers: options }, DEFAULT_OPTIONS);
   const runUntil = Date.now() + opts.lifetime;
+  const workerEnv = opts.env || {};
 
   let running = true;
 
   listen();
   masterFn();
-  fork(opts.env);
+  fork(workerEnv);
 
   function listen() {
     cluster.on('disconnect', revive);
@@ -79,7 +80,7 @@ module.exports = function throng(options, startFunction) {
 
   function revive(worker, code, signal) {
     setTimeout(forceKillWorker, opts.grace, worker).unref();
-    if (running && Date.now() < runUntil) cluster.fork();
+    if (running && Date.now() < runUntil) cluster.fork(workerEnv);
   }
 
   function forceKill() {

--- a/lib/throng.js
+++ b/lib/throng.js
@@ -36,7 +36,7 @@ module.exports = function throng(options, startFunction) {
 
   listen();
   masterFn();
-  fork();
+  fork(opts.env);
 
   function listen() {
     cluster.on('disconnect', revive);
@@ -49,9 +49,13 @@ module.exports = function throng(options, startFunction) {
     });
   }
 
-  function fork() {
+  /**
+   * See {@link https://nodejs.org/docs/latest-v10.x/api/cluster.html#cluster_cluster_fork_env}
+   * @param {Object} env Key/value pairs to add to worker process environment.
+   */
+  function fork(env) {
     for (let i = 0; i < opts.workers; i++) {
-      cluster.fork();
+      cluster.fork(env);
     }
   }
 


### PR DESCRIPTION
…ue pairs) to workers

* This allows results of expensive or otherwise limited computations to be performed once, and then propagated

This PR allows `throng` users to make use of the `env` parameter of [cluster.fork](https://nodejs.org/docs/latest-v10.x/api/cluster.html#cluster_cluster_fork_env)